### PR TITLE
checks.metadata_checks: add preserve-libs to known restricts

### DIFF
--- a/src/pkgcheck/metadata_checks.py
+++ b/src/pkgcheck/metadata_checks.py
@@ -657,7 +657,7 @@ class RestrictsReport(base.Template):
     feed_type = base.versioned_feed
     known_restricts = frozenset((
         "binchecks", "bindist", "fetch", "installsources", "mirror",
-        "primaryuri", "splitdebug", "strip", "test", "userpriv",
+        "preserve-libs", "primaryuri", "splitdebug", "strip", "test", "userpriv",
     ))
 
     known_results = (BadRestricts,) + addons.UseAddon.known_results


### PR DESCRIPTION
upstream version https://github.com/pkgcore/pkgcheck/pull/75

CI screams at me for no good reason =)

